### PR TITLE
Fix open-path intersection returning no results for horizontal paths

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -663,13 +663,17 @@ impl ClipperBase {
                 i += 1;
             }
             if i >= last_vert_idx {
-                return; // degenerate - all same y
-            }
-            going_up = self.vertex_arena[i].pt.y < first_pt.y;
-            if going_up {
+                // Completely horizontal open path - still add as local minimum
+                // so it participates in the sweep line (matches C++ Clipper2 behavior)
                 self.add_loc_min(first_vert_idx, polytype, true);
+                going_up = true;
             } else {
-                self.vertex_arena[first_vert_idx].flags |= VertexFlags::LOCAL_MAX;
+                going_up = self.vertex_arena[i].pt.y < first_pt.y;
+                if going_up {
+                    self.add_loc_min(first_vert_idx, polytype, true);
+                } else {
+                    self.vertex_arena[first_vert_idx].flags |= VertexFlags::LOCAL_MAX;
+                }
             }
         }
 

--- a/src/engine_tests.rs
+++ b/src/engine_tests.rs
@@ -854,3 +854,61 @@ fn test_polygon_case_37_difference_evenodd() {
         total_area as i64
     );
 }
+
+// ============================================================================
+// Issue #3: Open-path intersection returns no results for horizontal paths
+// ============================================================================
+
+#[test]
+fn test_horizontal_open_path_intersection() {
+    // A horizontal open line from (-10, 50) to (110, 50)
+    // clipped against a 100x100 rectangle (0,0)-(100,100)
+    // should return the segment (0, 50) -> (100, 50)
+    let open_subject = vec![vec![Point64::new(-10, 50), Point64::new(110, 50)]];
+    let clip = vec![vec![
+        Point64::new(0, 0),
+        Point64::new(100, 0),
+        Point64::new(100, 100),
+        Point64::new(0, 100),
+    ]];
+
+    let mut c = Clipper64::new();
+    c.add_open_subject(&open_subject);
+    c.add_clip(&clip);
+
+    let mut closed_result = Paths64::new();
+    let mut open_result = Paths64::new();
+    let success = c.execute(
+        ClipType::Intersection,
+        FillRule::EvenOdd,
+        &mut closed_result,
+        Some(&mut open_result),
+    );
+
+    assert!(success, "Clipper execute should succeed");
+    assert_eq!(
+        open_result.len(),
+        1,
+        "Expected 1 open path in result, got {}",
+        open_result.len()
+    );
+
+    let result_path = &open_result[0];
+    assert_eq!(
+        result_path.len(),
+        2,
+        "Expected 2 points in clipped segment, got {}",
+        result_path.len()
+    );
+
+    // The clipped segment should be from (0, 50) to (100, 50)
+    // (order may vary, so check both endpoints are present)
+    let mut pts: Vec<(i64, i64)> = result_path.iter().map(|p| (p.x, p.y)).collect();
+    pts.sort();
+    assert_eq!(
+        pts,
+        vec![(0, 50), (100, 50)],
+        "Expected clipped segment (0,50)-(100,50), got {:?}",
+        pts
+    );
+}


### PR DESCRIPTION
> [!NOTE]
> This PR was generated by AI and has not been properly human-supervised. Please review carefully.

## Summary
- Fixes #3: `add_open_subject` + `execute(Intersection)` returns no results for horizontal open paths
- The bug was in `find_and_add_local_minima_open` in `engine.rs`, where completely horizontal open paths (all vertices at the same Y) were incorrectly treated as "degenerate" and discarded without adding a local minimum
- Instead of returning early, horizontal open paths are now added as local minima with `going_up = true`, matching the C++ Clipper2 reference behavior

## Test plan
- [x] Added `test_horizontal_open_path_intersection`: horizontal line `(-10,50)->(110,50)` clipped against a 100x100 rectangle returns segment `(0,50)->(100,50)`
- [x] All 393 existing tests continue to pass
- [x] Verified all ClipType and FillRule variants produce correct results for both Clipper64 and ClipperD