### PR TITLE
Add PolyFace64 face extraction API

### DIFF
--- a/src/clipper.rs
+++ b/src/clipper.rs
@@ -410,6 +410,42 @@ pub fn rect_clip_line_d(rect: &RectD, line: &PathD, precision: i32) -> PathsD {
 // PolyTree conversion
 // ============================================================================
 
+/// A solid polygon face extracted from a `PolyTree64`.
+///
+/// `outer` is a filled contour. `holes` contains only the immediate hole
+/// children of that contour; islands nested inside those holes are returned as
+/// separate `PolyFace64` values.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PolyFace64 {
+    pub node_index: usize,
+    pub depth: u32,
+    pub outer: Path64,
+    pub holes: Paths64,
+    pub hole_node_indices: Vec<usize>,
+}
+
+fn poly_tree_node_level(tree: &PolyTree64, node_idx: usize) -> Option<u32> {
+    let mut level = 0u32;
+    let mut parent = tree.nodes.get(node_idx)?.parent();
+    let mut visited = 0usize;
+
+    while let Some(parent_idx) = parent {
+        visited += 1;
+        if visited > tree.nodes.len() {
+            return None;
+        }
+        level += 1;
+        parent = tree.nodes.get(parent_idx)?.parent();
+    }
+
+    Some(level)
+}
+
+fn poly_tree_node_is_hole(tree: &PolyTree64, node_idx: usize) -> Option<bool> {
+    let level = poly_tree_node_level(tree, node_idx)?;
+    Some(level > 0 && (level & 1) == 0)
+}
+
 /// Helper: recursively collect paths from a PolyPath64 node.
 fn poly_path_to_paths64(tree: &PolyTree64, node_idx: usize, paths: &mut Paths64) {
     let polygon = tree.nodes[node_idx].polygon().clone();
@@ -440,6 +476,63 @@ pub fn poly_tree_to_paths64(polytree: &PolyTree64) -> Paths64 {
     for &child_idx in root.children() {
         poly_path_to_paths64(polytree, child_idx, &mut result);
     }
+    result
+}
+
+fn poly_path_to_faces64(tree: &PolyTree64, node_idx: usize, faces: &mut Vec<PolyFace64>) {
+    let Some(node) = tree.nodes.get(node_idx) else {
+        return;
+    };
+
+    if !node.polygon().is_empty() && matches!(poly_tree_node_is_hole(tree, node_idx), Some(false)) {
+        let mut holes = Paths64::new();
+        let mut hole_node_indices = Vec::new();
+        for child_idx in node.children().iter().copied() {
+            if !matches!(poly_tree_node_is_hole(tree, child_idx), Some(true)) {
+                continue;
+            }
+            let Some(child_node) = tree.nodes.get(child_idx) else {
+                continue;
+            };
+            if child_node.polygon().is_empty() {
+                continue;
+            }
+            holes.push(child_node.polygon().clone());
+            hole_node_indices.push(child_idx);
+        }
+
+        faces.push(PolyFace64 {
+            node_index: node_idx,
+            depth: poly_tree_node_level(tree, node_idx).unwrap_or(0),
+            outer: node.polygon().clone(),
+            holes,
+            hole_node_indices,
+        });
+    }
+
+    let children: Vec<usize> = node.children().to_vec();
+    for child_idx in children {
+        poly_path_to_faces64(tree, child_idx, faces);
+    }
+}
+
+/// Convert a `PolyTree64` into solid faces with immediate hole ownership.
+///
+/// Each non-hole node becomes one `PolyFace64`. Immediate hole children are
+/// attached to that face. Nested islands below those holes are returned as
+/// independent faces.
+#[must_use]
+pub fn poly_tree_to_faces64(polytree: &PolyTree64) -> Vec<PolyFace64> {
+    let mut result = Vec::new();
+    let Some(root) = polytree.nodes.first() else {
+        return result;
+    };
+
+    let root_children: Vec<usize> = root.children().to_vec();
+    for child_idx in root_children {
+        poly_path_to_faces64(polytree, child_idx, &mut result);
+    }
+
     result
 }
 

--- a/src/clipper_tests.rs
+++ b/src/clipper_tests.rs
@@ -515,6 +515,53 @@ fn test_poly_tree_to_paths64() {
 }
 
 #[test]
+fn test_poly_tree_to_faces64_groups_immediate_holes() {
+    let mut tree = PolyTree64::new();
+    let outer = square_64(0, 0, 100);
+    let hole = square_64(0, 0, 50);
+    let island = square_64(0, 0, 25);
+
+    let outer_idx = tree.add_child(0, outer.clone());
+    let hole_idx = tree.add_child(outer_idx, hole.clone());
+    let island_idx = tree.add_child(hole_idx, island.clone());
+
+    let faces = poly_tree_to_faces64(&tree);
+
+    assert_eq!(faces.len(), 2);
+    assert_eq!(faces[0].node_index, outer_idx);
+    assert_eq!(faces[0].depth, 1);
+    assert_eq!(faces[0].outer, outer);
+    assert_eq!(faces[0].holes, vec![hole]);
+    assert_eq!(faces[0].hole_node_indices, vec![hole_idx]);
+    assert_eq!(faces[1].node_index, island_idx);
+    assert_eq!(faces[1].depth, 3);
+    assert_eq!(faces[1].outer, island);
+    assert!(faces[1].holes.is_empty());
+    assert!(faces[1].hole_node_indices.is_empty());
+}
+
+#[test]
+fn test_boolean_tree_to_faces64_difference_has_one_hole() {
+    let subjects = vec![square_64(0, 0, 100)];
+    let clips = vec![square_64(0, 0, 50)];
+    let mut tree = PolyTree64::new();
+    boolean_op_tree_64(
+        ClipType::Difference,
+        FillRule::NonZero,
+        &subjects,
+        &clips,
+        &mut tree,
+    );
+
+    let faces = poly_tree_to_faces64(&tree);
+
+    assert_eq!(faces.len(), 1);
+    assert_eq!(faces[0].holes.len(), 1);
+    assert!(!faces[0].outer.is_empty());
+    assert!(!faces[0].holes[0].is_empty());
+}
+
+#[test]
 fn test_poly_tree_to_paths_d_empty() {
     let tree = PolyTreeD::new();
     let result = poly_tree_to_paths_d(&tree);


### PR DESCRIPTION
## Summary
- Expose poly_tree_to_faces64 to return faces with metadata for downstream ownership.
- Add coverage for immediate-hole grouping behavior.
- Add coverage for boolean difference face output.